### PR TITLE
fix: use npm releases and add links to packages

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,8 +19,8 @@
 
 | Name | Description | Repo | Latest Release | 
 |------|--------------|------| ---------------|
-| [iApp Generator](https://docs.iex.ec/references/iapp-generator) | CLI tool to scaffold and deploy iExec Confidential Apps | [iExecBlockchainComputing/iapp](https://github.com/iExecBlockchainComputing/iapp) | ![Latest Release](https://img.shields.io/github/v/release/iExecBlockchainComputing/iapp) |
-| [Data Protector](https://docs.iex.ec/references/dataProtector/getting-started) | Protect and share data using a decentralized privacy layer | [iExecBlockchainComputing/dataprotector-sdk](https://github.com/iExecBlockchainComputing/dataprotector-sdk) | ![Latest Release](https://img.shields.io/github/v/release/iExecBlockchainComputing/dataprotector-sdk) |
+| [iApp Generator](https://docs.iex.ec/references/iapp-generator) | CLI tool to scaffold and deploy iExec Confidential Apps | [iExecBlockchainComputing/iapp](https://github.com/iExecBlockchainComputing/iapp) | [![Latest Release](https://img.shields.io/npm/v/%40iexec%2Fiapp)](https://www.npmjs.com/package/@iexec/iapp) |
+| [Data Protector](https://docs.iex.ec/references/dataProtector/getting-started) | Protect and share data using a decentralized privacy layer | [iExecBlockchainComputing/dataprotector-sdk](https://github.com/iExecBlockchainComputing/dataprotector-sdk) | [![Latest Release](https://img.shields.io/npm/v/%40iexec%2Fdataprotector)](https://www.npmjs.com/package/@iexec/dataprotector) |
 
 ---
 


### PR DESCRIPTION
- iapp and dataprotector-sdk are monorepos using the versioning from github release will display the version of the last subcomponent updated => use npm SDK package versioning instead which is the component that matters for the developer
- click on the badge opens the badge image in a new tab => open the package page

| before | after |
|---|---|
| <img width="162" height="172" alt="image" src="https://github.com/user-attachments/assets/00576eaf-a9fd-42e1-ac23-cc924c1ba162" /> | <img width="162" height="172" alt="image" src="https://github.com/user-attachments/assets/4e0d1cec-5b97-46a1-bc8b-e2efcd1fcc38" /> |